### PR TITLE
fix missing parameter passing to printf

### DIFF
--- a/ppool_errno.c
+++ b/ppool_errno.c
@@ -7,7 +7,7 @@ void ppool_error(const char *msg)
     if(!msg)
         printf("%s\n",ppool_strerr(ppool_errno));
     else
-        printf("%s : %s\n",ppool_strerr(ppool_errno));
+        printf("%s : %s\n",ppool_strerr(ppool_errno), msg);
 }
 
 char *ppool_strerr(int errno)


### PR DESCRIPTION
在 ppool_error 函数里面你一定是希望在 msg 不为 NULL 的时候将其传递给 printf 打印出来，但这里很明显忘加了。这段代码在开了 -Werror 时可能编译不通过。